### PR TITLE
[maint] Make example figures have larger dpi

### DIFF
--- a/examples/doppler.py
+++ b/examples/doppler.py
@@ -265,7 +265,7 @@ print("\n📊 Creating visualization...")
 power_doppler_db = db_zero(power_doppler_2d)
 
 # Plot along with axis labels
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(figsize=(8, 6), dpi=300)
 extent = [x.min() * MM_PER_METER, x.max() * MM_PER_METER, z.max() * MM_PER_METER, z.min() * MM_PER_METER]
 im = ax.imshow(
     power_doppler_db.T,

--- a/examples/plane_wave_compound.py
+++ b/examples/plane_wave_compound.py
@@ -178,7 +178,7 @@ print("\n📊 Visualizing B-mode...")
 bmode_db = db_zero(beamformed_image)
 
 # Create high-quality visualization
-fig, ax = plt.subplots(figsize=(12, 8))
+fig, ax = plt.subplots(figsize=(8, 8), dpi=300)
 
 # Set up coordinate system for proper display
 extent = [


### PR DESCRIPTION
previously matplotlib has default dpi=100, so figures were a little grainy