### PR TITLE
[maint] use complex64 in PyMUST to match the GPU implementations

### DIFF
--- a/tests/compare/test_pymust.py
+++ b/tests/compare/test_pymust.py
@@ -103,6 +103,8 @@ def pymust_das_matrix(pymust_iq_data, pymust_meshgrid, pymust_params):
 
     # Create DAS matrix once (it's the same for all frames)
     M = pymust.dasmtx(1j * np.array(pymust_iq_data.shape[:2]), x_grid, z_grid, pymust_params)
+    # All the GPU methods use complex64, so let's do the same to be consistent
+    M = M.astype(np.complex64)
     return M
 
 


### PR DESCRIPTION
#### Introduction

GPU implementations use complex64 precision by default. This does affect runtime (mostly because of memory access)

#### Changes

* Use complex64 in the PyMUST benchmark

#### Behavior

Did not update the benchmark figure yet because `vbeam` seems to have slowed down, so I'll track down where that comes from (or maybe the previous benchmarks were unexpectedly fast)?

* pyMUST benchmark is down to 90ms?

#### Review checklist

- [x] All existing tests and checks pass
- [x] Unit tests covering the new feature or bugfix have been added
- [ ] The documentation has been updated if necessary
