### PR TITLE
[bump] v0.0.3

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.0.2"
+current_version = "0.0.3"
 commit = true
 allow_dirty = false
 commit_args = "--no-verify"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -15,6 +15,6 @@ replace = 'version = "{new_version}"'
 
 [[tool.bumpversion.files]]
 # Update version in __init__.py
-filename = "mach/__init__.py"
+filename = "src/mach/__init__.py"
 search = '__version__ = "{current_version}"'
 replace = '__version__ = "{new_version}"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mach-beamform"
-version = "0.0.2"  # Update via bump-my-version, not manually
+version = "0.0.3"  # Update via bump-my-version, not manually
 description = "Ultrafast GPU-accelerated beamforming kernel for ultrasound imaging"
 authors = [
     { name = "Charles Guan" },

--- a/src/mach/__init__.py
+++ b/src/mach/__init__.py
@@ -11,4 +11,4 @@ try:
     __version__ = version("mach")
 except PackageNotFoundError:
     # Update via bump-my-version, not manually
-    __version__ = "0.0.2"
+    __version__ = "0.0.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1945,7 +1945,7 @@ wheels = [
 
 [[package]]
 name = "mach-beamform"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "array-api-compat" },


### PR DESCRIPTION
https://github.com/Forest-Neurotech/mach/issues/32

#### Introduction

PyPI wheels don't currently include the `mach` python files; think this might have to do with a previous issue with the `src` layout. main already works, so just need to re-release

#### Changes

* bump the version
* re-release v0.0.3
 
#### Behavior

* wheels build should work. I'll download and confirm, then merge and trigger a build

#### Review checklist

- [ ] All existing tests and checks pass
