### PR TITLE
[feature] nearest neighbor interpolation as an option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ compile: check-system-dep ## Compiles the CUDA extension with nanobind
 	# Not sure if the pip command is also needed
 	uv pip install -ve . --no-build-isolation
 
+.PHONY: stubgen
+stubgen: ## Generates the type-hint stub file for the nanobind-CUDA module
+	uv run --group build -m nanobind.stubgen -m mach._cuda_impl -O src/mach/
+
 .PHONY: check
 check: ## Checks the code
 	@echo "🚀 Checking lock file consistency with 'pyproject.toml'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "test_*.py" = ["S101"]
 "tests/*" = ["S101", "RUF001", "RUF003"]
+"src/mach/_cuda_impl.pyi" = ["C408"]  # nanobind.stubgen uses dict()
 
 [tool.ruff.format]
 preview = true

--- a/src/mach/_cuda_impl.pyi
+++ b/src/mach/_cuda_impl.pyi
@@ -1,23 +1,48 @@
-"""Type stubs for the nanobind-generated _cuda_impl module."""
+import enum
+from typing import Annotated, overload
 
-from typing import Optional
+from numpy.typing import ArrayLike
 
-from mach._array_api import Array
+__nvcc_version__: str = "12.4.131"
 
-# Version information exposed by nanobind
-__nvcc_version__: str
+class InterpolationType(enum.Enum):
+    NearestNeighbor = 0
+    """Use nearest neighbor interpolation (fastest)"""
 
-# Beamforming function from nanobind
+    Linear = 1
+    """Use linear interpolation (default, higher quality)"""
+
+NearestNeighbor: InterpolationType = InterpolationType.NearestNeighbor
+
+Linear: InterpolationType = InterpolationType.Linear
+
+@overload
 def beamform(
-    channel_data: Array,
-    rx_coords_m: Array,
-    scan_coords_m: Array,
-    tx_wave_arrivals_s: Array,
-    out: Optional[Array],
+    channel_data: Annotated[ArrayLike, dict(dtype="complex64", shape=(None, None, None), order="C", writable=False)],
+    rx_coords_m: Annotated[ArrayLike, dict(dtype="float32", shape=(None, 3), order="C", writable=False)],
+    scan_coords_m: Annotated[ArrayLike, dict(dtype="float32", shape=(None, 3), order="C", writable=False)],
+    tx_wave_arrivals_s: Annotated[ArrayLike, dict(dtype="float32", shape=(None), order="C", writable=False)],
+    out: Annotated[ArrayLike, dict(dtype="complex64", shape=(None, None), order="C")],
     f_number: float,
     rx_start_s: float,
     sampling_freq_hz: float,
     sound_speed_m_s: float,
     modulation_freq_hz: float,
     tukey_alpha: float = 0.5,
-) -> Array: ...
+    interp_type: InterpolationType = InterpolationType.Linear,
+) -> None: ...
+@overload
+def beamform(
+    channel_data: Annotated[ArrayLike, dict(dtype="float32", shape=(None, None, None), order="C", writable=False)],
+    rx_coords_m: Annotated[ArrayLike, dict(dtype="float32", shape=(None, 3), order="C", writable=False)],
+    scan_coords_m: Annotated[ArrayLike, dict(dtype="float32", shape=(None, 3), order="C", writable=False)],
+    tx_wave_arrivals_s: Annotated[ArrayLike, dict(dtype="float32", shape=(None), order="C", writable=False)],
+    out: Annotated[ArrayLike, dict(dtype="float32", shape=(None, None), order="C")],
+    f_number: float,
+    rx_start_s: float,
+    sampling_freq_hz: float,
+    sound_speed_m_s: float,
+    modulation_freq_hz: float = 0.0,
+    tukey_alpha: float = 0.5,
+    interp_type: InterpolationType = InterpolationType.Linear,
+) -> None: ...

--- a/src/mach/kernel.cu
+++ b/src/mach/kernel.cu
@@ -117,14 +117,14 @@ __device__ __forceinline__ DataType interpolate_nearest(
         is_valid = false;
         return DataType{};  // Return default-constructed value (won't be used)
     }
-    
+
     const unsigned int sample_idx_round = __float2uint_rn(sample_idx);  // Round to nearest
     DEBUG_ASSERT(sample_idx_round < n_samples);  // Verify sample index is in bounds
     const uint32_t channel_data_idx = receive_element_idx * n_samples * n_frames +
                                      sample_idx_round * n_frames +
                                      frame_idx;
-    DEBUG_ASSERT(channel_data_idx < static_cast<uint64_t>(n_samples) * n_frames * (receive_element_idx + 1));  // Verify channel data index is in bounds  
-    
+    DEBUG_ASSERT(channel_data_idx < static_cast<uint64_t>(n_samples) * n_frames * (receive_element_idx + 1));  // Verify channel data index is in bounds
+
     is_valid = true;
     return channel_data[channel_data_idx];
 }
@@ -156,24 +156,24 @@ __device__ __forceinline__ DataType interpolate_linear(
         is_valid = false;
         return DataType{};  // Return default-constructed value (won't be used)
     }
-    
+
     const unsigned int sample_idx_floor = __float2uint_rd(sample_idx);
     const unsigned int sample_idx_ceil = __float2uint_ru(sample_idx);
     const float lerp_alpha = sample_idx - (float)sample_idx_floor;
-    
+
     DEBUG_ASSERT(sample_idx_floor < n_samples);  // Verify floor sample index is in bounds
     DEBUG_ASSERT(sample_idx_ceil < n_samples);   // Verify ceil sample index is in bounds
-    
+
     const uint32_t channel_data_idx_floor = receive_element_idx * n_samples * n_frames +
                                            sample_idx_floor * n_frames +
                                            frame_idx;
     const uint32_t channel_data_idx_ceil = receive_element_idx * n_samples * n_frames +
                                           sample_idx_ceil * n_frames +
                                           frame_idx;
-    
+
     DEBUG_ASSERT(channel_data_idx_floor < static_cast<uint64_t>(n_samples) * n_frames * (receive_element_idx + 1));  // Verify floor channel data index is in bounds
     DEBUG_ASSERT(channel_data_idx_ceil < static_cast<uint64_t>(n_samples) * n_frames * (receive_element_idx + 1));   // Verify ceil channel data index is in bounds
-    
+
     is_valid = true;
     return lerp(channel_data[channel_data_idx_floor], channel_data[channel_data_idx_ceil], lerp_alpha);
 }
@@ -566,7 +566,7 @@ __global__ void beamformKernel(
             DataType sensor_sample = interpolate_sample<DataType, interpType>(
                 channel_data, sample_idx, receive_element_idx, frame_idx, n_samples, n_frames, is_valid
             );
-            
+
             // Skip if sample is outside bounds
             if (!is_valid) continue;
 

--- a/src/mach/kernel.py
+++ b/src/mach/kernel.py
@@ -9,12 +9,14 @@ from mach._array_api import Array, array_namespace
 from mach._check import ensure_contiguous, is_contiguous
 
 # Import from the nanobind module
-from ._cuda_impl import __nvcc_version__  # type: ignore[attr-defined]  # noqa: F401
+from ._cuda_impl import (
+    InterpolationType,  # type: ignore[attr-defined]
+    __nvcc_version__,  # type: ignore[attr-defined]  # noqa: F401
+)
 from ._cuda_impl import beamform as nb_beamform  # type: ignore[attr-defined]
-from ._cuda_impl import InterpolationType  # type: ignore[attr-defined]
 
 # Export the InterpolationType enum for public use
-__all__ = ["beamform", "InterpolationType"]
+__all__ = ["InterpolationType", "beamform"]
 
 
 def beamform(  # noqa: C901

--- a/src/mach/kernel.py
+++ b/src/mach/kernel.py
@@ -11,6 +11,10 @@ from mach._check import ensure_contiguous, is_contiguous
 # Import from the nanobind module
 from ._cuda_impl import __nvcc_version__  # type: ignore[attr-defined]  # noqa: F401
 from ._cuda_impl import beamform as nb_beamform  # type: ignore[attr-defined]
+from ._cuda_impl import InterpolationType  # type: ignore[attr-defined]
+
+# Export the InterpolationType enum for public use
+__all__ = ["beamform", "InterpolationType"]
 
 
 def beamform(  # noqa: C901
@@ -26,6 +30,7 @@ def beamform(  # noqa: C901
     sound_speed_m_s: float,
     modulation_freq_hz: Optional[float] = None,
     tukey_alpha: float = 0.5,
+    interp_type: InterpolationType = InterpolationType.Linear,
 ) -> Array:
     """CUDA ultrasound beamforming with automatic GPU/CPU dispatch.
 
@@ -93,6 +98,10 @@ def beamform(  # noqa: C901
             - 0.0: no apodization (rectangular window)
             - 0.5: moderate apodization (default)
             - 1.0: maximum apodization (Hann window)
+        interp_type:
+            Interpolation method for sensor data sampling. Options:
+            - InterpolationType.Linear: Linear interpolation (default, higher quality)
+            - InterpolationType.NearestNeighbor: Nearest neighbor (faster, lower quality)
 
     Returns:
         Beamformed data with shape (n_scan, nframes).
@@ -135,6 +144,20 @@ def beamform(  # noqa: C901
         ...     sampling_freq_hz=40e6,
         ...     f_number=1.5,
         ...     sound_speed_m_s=1540
+        ... )
+        >>>
+        >>> # Use nearest neighbor interpolation for faster processing
+        >>> from mach.kernel import InterpolationType
+        >>> result_fast = beamform(
+        ...     channel_data=channel_data,
+        ...     rx_coords_m=rx_positions,
+        ...     scan_coords_m=scan_points,
+        ...     tx_wave_arrivals_s=tx_arrivals,
+        ...     rx_start_s=0.0,
+        ...     sampling_freq_hz=40e6,
+        ...     f_number=1.5,
+        ...     sound_speed_m_s=1540,
+        ...     interp_type=InterpolationType.NearestNeighbor
         ... )
     """
 
@@ -245,6 +268,7 @@ def beamform(  # noqa: C901
         sound_speed_m_s=sound_speed_m_s,
         modulation_freq_hz=modulation_freq_hz,
         tukey_alpha=tukey_alpha,
+        interp_type=interp_type,
     )
 
     return out

--- a/tests/test_nanobind.py
+++ b/tests/test_nanobind.py
@@ -8,7 +8,7 @@ from array_api_compat import is_cupy_namespace, is_jax_namespace, is_numpy_names
 
 import mach
 from mach._array_api import array_namespace
-from mach.kernel import beamform
+from mach.kernel import InterpolationType, beamform
 
 
 def create_test_data(xp: Any) -> tuple[Any, Any, Any, Any, Any, int, int, int, int]:
@@ -206,14 +206,18 @@ def test_beamform_mixed_cpu_gpu_arrays(xp, test_data):
 
 
 @pytest.mark.parametrize(
-    "f_number,alpha",
-    [
-        (1.0, 0.2),
-        (2.0, 0.5),
-        (3.0, 0.8),
-    ],
+    "f_number",
+    [1.0, 3.0],
 )
-def test_beamform_parameters(xp, test_data, f_number, alpha):
+@pytest.mark.parametrize(
+    "alpha",
+    [0.0, 1.0],
+)
+@pytest.mark.parametrize(
+    "interp_type",
+    [InterpolationType.Linear, InterpolationType.NearestNeighbor],
+)
+def test_beamform_parameters(xp, test_data, f_number, alpha, interp_type):
     """Test beamforming with different parameter values."""
     _, rf_complex, coords, grid, idt_matrix, nframes, _, _, n_scan_points = test_data
 
@@ -237,6 +241,7 @@ def test_beamform_parameters(xp, test_data, f_number, alpha):
         sound_speed_m_s=1500.0,
         modulation_freq_hz=5e6,
         tukey_alpha=alpha,
+        interp_type=interp_type,
     )
 
     # Verify output shape


### PR DESCRIPTION
Related to: https://github.com/Forest-Neurotech/mach/issues/13

#### Introduction

we currently default to linear interpolation. on occasion, there is use for nearest-neighbor interpolation. 

#### Changes

* add nearest-neighbor interpolation as an option flag

#### Behavior

* default behavior is the same

#### Review checklist

- [x] All existing tests and checks pass
- [x] Unit tests covering the new feature or bugfix have been added
- [ ] The documentation has been updated if necessary
