### PR TITLE
[feature] Add quadratic interpolation to the CUDA kernel

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -29,6 +29,10 @@ We use PyMUST's [rotating-disk Doppler dataset](https://github.com/creatis-ULTIM
 
 This represents a realistic ultrafast imaging workload, although it is a small microbenchmark compared to the 3D, high-channel count datasets we're actually interested in.
 
+The benchmark scripts use the following settings:
+* linear interpolation
+* f-number: `1.0`
+
 ## Performance Results
 
 ![Benchmark Results](assets/benchmark-doppler_disk.svg)

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ We welcome contributions! Please see [CONTRIBUTING.md](https://github.com/Forest
 - ✅ Allow NumPy/CuPy/JAX/PyTorch inputs through Array API
 - ✅ Comprehensive error handling
 - ✅ PyPI packaging and distribution
+- ✅ Interpolation options: nearest, linear, and quadratic
 
 ### Numerically validated, but looking for feedback on API
 - ✅ Coherent compounding
 
 ### Tentative Future Plans
-- Additional interpolation methods (spline, sinc)
 - Additional apodization windows
 
 See the [project page](https://github.com/orgs/Forest-Neurotech/projects/14) for our up-to-date roadmap.

--- a/src/mach/_cuda_impl.pyi
+++ b/src/mach/_cuda_impl.pyi
@@ -10,11 +10,16 @@ class InterpolationType(enum.Enum):
     """Use nearest neighbor interpolation (fastest)"""
 
     Linear = 1
-    """Use linear interpolation (default, higher quality)"""
+    """Use linear interpolation (default, good balance)"""
+
+    Quadratic = 2
+    """Use quadratic interpolation (higher quality)"""
 
 NearestNeighbor: InterpolationType = InterpolationType.NearestNeighbor
 
 Linear: InterpolationType = InterpolationType.Linear
+
+Quadratic: InterpolationType = InterpolationType.Quadratic
 
 @overload
 def beamform(

--- a/src/mach/kernel.py
+++ b/src/mach/kernel.py
@@ -102,8 +102,9 @@ def beamform(  # noqa: C901
             - 1.0: maximum apodization (Hann window)
         interp_type:
             Interpolation method for sensor data sampling. Options:
-            - InterpolationType.Linear: Linear interpolation (default, higher quality)
-            - InterpolationType.NearestNeighbor: Nearest neighbor (faster, lower quality)
+            - InterpolationType.NearestNeighbor: Nearest neighbor (fastest, lower quality)
+            - InterpolationType.Linear: Linear interpolation (default, good balance)
+            - InterpolationType.Quadratic: Quadratic interpolation (higher quality, slower)
 
     Returns:
         Beamformed data with shape (n_scan, nframes).
@@ -160,6 +161,19 @@ def beamform(  # noqa: C901
         ...     f_number=1.5,
         ...     sound_speed_m_s=1540,
         ...     interp_type=InterpolationType.NearestNeighbor
+        ... )
+        >>>
+        >>> # Use quadratic interpolation for highest quality
+        >>> result_hq = beamform(
+        ...     channel_data=channel_data,
+        ...     rx_coords_m=rx_positions,
+        ...     scan_coords_m=scan_points,
+        ...     tx_wave_arrivals_s=tx_arrivals,
+        ...     rx_start_s=0.0,
+        ...     sampling_freq_hz=40e6,
+        ...     f_number=1.5,
+        ...     sound_speed_m_s=1540,
+        ...     interp_type=InterpolationType.Quadratic
         ... )
     """
 

--- a/tests/test_nanobind.py
+++ b/tests/test_nanobind.py
@@ -215,7 +215,7 @@ def test_beamform_mixed_cpu_gpu_arrays(xp, test_data):
 )
 @pytest.mark.parametrize(
     "interp_type",
-    [InterpolationType.Linear, InterpolationType.NearestNeighbor],
+    [InterpolationType.Linear, InterpolationType.NearestNeighbor, InterpolationType.Quadratic],
 )
 def test_beamform_parameters(xp, test_data, f_number, alpha, interp_type):
     """Test beamforming with different parameter values."""


### PR DESCRIPTION
https://github.com/Forest-Neurotech/mach/issues/13

#### Introduction

Sometimes higher-order interpolation is helpful. It's supported by a few of the other beamforming libraries.

#### Changes

* Add quadratic interpolation to kernel
* expose it through a enum flag
* does not profile the testing

#### Behavior

mach output looks very similar:
<img width="2002" height="590" alt="image" src="https://github.com/user-attachments/assets/220e5cdc-c6f5-477a-89f7-db9c97404962" />

some slight impact on the doppler disk dataset
<img width="2002" height="590" alt="image" src="https://github.com/user-attachments/assets/a699e2c4-0fce-4edf-a359-b744c9ac3d39" />


#### Review checklist

- [x] All existing tests and checks pass
- [x] Unit tests covering the new feature or bugfix have been added
- [x] The documentation has been updated if necessary
