### PR TITLE
Build native cubins for Ada (sm_89) and Hopper (sm_90)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,19 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS_INIT} ${CMAKE_CUDA_FLAGS}")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --ptxas-options=-v")
 # debug info
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --generate-line-info")
-# Compute-capability 7.5+, to support Github T4 runner
+# Build native SASS for every GPU we deploy on. Shipping a native cubin per
+# arch avoids relying on PTX JIT at load time -- a JIT only happens when no
+# cubin matches the device, and it requires a driver at least as new as the
+# build toolkit. A device whose arch has no cubin therefore fails on an older
+# driver: e.g. an L4 (sm_89) on an R535/CUDA-12.2 driver (the version Dataflow
+# ships) cannot JIT this package's CUDA-12.x PTX and dies with
+# cudaErrorUnsupportedPtxVersion. Native cubins are gated only by hardware
+# support, so they run regardless of driver age.
+#   75  = Turing  (T4; GitHub CI runner)
+#   89  = Ada     (L4, A40, RTX 40-series)
+#   90  = Hopper  (H100/H200)
 # https://developer.nvidia.com/cuda-gpus
-set(CMAKE_CUDA_ARCHITECTURES 75)
+set(CMAKE_CUDA_ARCHITECTURES 75 89 90)
 
 # nanobind requires GCC 8+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,15 +55,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --generate-line-info")
 # Build native SASS for every GPU we deploy on. Shipping a native cubin per
 # arch avoids relying on PTX JIT at load time -- a JIT only happens when no
 # cubin matches the device, and it requires a driver at least as new as the
-# build toolkit. A device whose arch has no cubin therefore fails on an older
-# driver: e.g. an L4 (sm_89) on an R535/CUDA-12.2 driver (the version Dataflow
-# ships) cannot JIT this package's CUDA-12.x PTX and dies with
-# cudaErrorUnsupportedPtxVersion. Native cubins are gated only by hardware
-# support, so they run regardless of driver age.
-#   75  = Turing  (T4; GitHub CI runner)
-#   89  = Ada     (L4, A40, RTX 40-series)
-#   90  = Hopper  (H100/H200)
-# https://developer.nvidia.com/cuda-gpus
+# build toolkit.
 set(CMAKE_CUDA_ARCHITECTURES 75 89 90)
 
 # nanobind requires GCC 8+


### PR DESCRIPTION
## Problem

`CMAKE_CUDA_ARCHITECTURES` is `75` only (Turing/T4, for the GitHub CI runner), so the published wheel ships an `sm_75` cubin plus `compute_75` PTX — and nothing else.

On a **non-Turing** GPU there's no matching cubin, so the driver must **JIT the PTX** at load time. A PTX JIT requires a driver **at least as new as the toolkit that emitted the PTX** (this package's is CUDA 12.x). That breaks on Google Cloud **Dataflow**, whose GPU workers run an **R535 / CUDA 12.2** driver.

- L4 = `sm_89` → no native cubin → driver tries to JIT `compute_75` PTX
- the PTX is ISA 8.3 (CUDA 12.3); R535 only parses ≤ 8.2 (CUDA 12.2)

### Why it wasn't caught

The failure needs **two** things at once: a GPU that isn't `sm_75` (forces a JIT) **and** a driver too old to JIT the PTX. Neither dev nor CI hits both:

| Environment | GPU | Driver | Path | Result |
|---|---|---|---|---|
| GitHub CI | T4 `sm_75` | — | native `sm_75` cubin, no JIT | ✅ |
| pathfinder | RTX 5090 `sm_120` | R580 / CUDA 13 | JITs PTX (new driver can) | ✅ |
| **Dataflow** | **L4 `sm_89`** | **R535 / CUDA 12.2** | must JIT, old driver can't | ❌ 222 |

## Fix

```cmake
set(CMAKE_CUDA_ARCHITECTURES 75 89 90)
```

- `75` Turing (T4 / CI) — unchanged
- `89` Ada (L4, A40, RTX 40-series)
- `90` Hopper (H100/H200)

## Verification

On `sm_89` hardware (RTX 4090):
- `ptxas` compiles this package's PTX cleanly to both `sm_89` and `sm_90`.
- A beamform with a locally-rebuilt `sm_89`-native `_cuda_impl.so` produces **bit-identical** output (`max abs diff 0.0`) to the original `sm_75`+PTX (JIT'd) path — same math, just no JIT.

## Notes

- A release (e.g. `0.1.2`) is needed for downstream consumers (mergelabs pins `mach-beamform`) to pick this up.