### PR TITLE
Add Flox development environment for CUDA builds

### DIFF
--- a/.flox/.gitattributes
+++ b/.flox/.gitattributes
@@ -1,0 +1,1 @@
+env/manifest.lock linguist-generated=true linguist-language=JSON

--- a/.flox/.gitignore
+++ b/.flox/.gitignore
@@ -1,0 +1,5 @@
+run/
+cache/
+lib/
+log/
+!env/

--- a/.flox/env.json
+++ b/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "mach",
+  "version": 1
+}

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -1,0 +1,474 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.12.0",
+    "install": {
+      "cuda_cudart": {
+        "pkg-path": "flox-cuda/cudaPackages_12_2.cuda_cudart",
+        "priority": 2,
+        "systems": [
+          "aarch64-linux",
+          "x86_64-linux"
+        ],
+        "outputs": [
+          "out",
+          "static"
+        ]
+      },
+      "cuda_nvcc": {
+        "pkg-path": "flox-cuda/cudaPackages_12_2.cuda_nvcc",
+        "priority": 1,
+        "systems": [
+          "aarch64-linux",
+          "x86_64-linux"
+        ]
+      },
+      "cudatoolkit": {
+        "pkg-path": "flox-cuda/cudaPackages_12_2.cudatoolkit",
+        "priority": 3,
+        "systems": [
+          "aarch64-linux",
+          "x86_64-linux"
+        ]
+      },
+      "gcc": {
+        "pkg-path": "gcc12",
+        "priority": 4,
+        "systems": [
+          "aarch64-linux",
+          "x86_64-linux"
+        ]
+      },
+      "gnumake": {
+        "pkg-path": "gnumake",
+        "pkg-group": "build",
+        "systems": [
+          "aarch64-linux",
+          "x86_64-linux"
+        ]
+      },
+      "uv": {
+        "pkg-path": "uv",
+        "pkg-group": "build",
+        "version": "0.9.28",
+        "systems": [
+          "aarch64-linux",
+          "x86_64-linux"
+        ]
+      }
+    },
+    "vars": {
+      "CC": "gcc",
+      "CUDA_HOME": "$FLOX_ENV",
+      "CUDA_VERSION": "12.2",
+      "CXX": "g++",
+      "LIBRARY_PATH": "$FLOX_ENV/lib:$FLOX_ENV/lib/stubs"
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-linux",
+        "x86_64-linux"
+      ]
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "gnumake",
+      "broken": false,
+      "derivation": "/nix/store/n3nk5kyi8ckasq265skqni13m34d2v20-gnumake-4.4.1.drv",
+      "description": "Tool to control the generation of non-source files from sources",
+      "install_id": "gnumake",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+      "name": "gnumake-4.4.1",
+      "pname": "gnumake",
+      "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+      "rev_count": 940249,
+      "rev_date": "2026-02-04T09:32:58Z",
+      "scrape_date": "2026-02-06T05:05:24.891998Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "4.4.1",
+      "outputs_to_install": [
+        "man",
+        "man",
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/4wnafz38wr2jld58vr5j41b6mc4n26r6-gnumake-4.4.1-debug",
+        "doc": "/nix/store/15r3aanv0lh7mqi1gm3l8blpcnp05qzy-gnumake-4.4.1-doc",
+        "info": "/nix/store/gjd78rqz1k94n1c2s2kip126f8gjbb6g-gnumake-4.4.1-info",
+        "man": "/nix/store/i0rnnv9fm87c0228z34pgvk24ifqn6bm-gnumake-4.4.1-man",
+        "out": "/nix/store/z9wllcd2plhx8863ka0zfh0mffxm6jir-gnumake-4.4.1"
+      },
+      "system": "aarch64-linux",
+      "group": "build",
+      "priority": 5
+    },
+    {
+      "attr_path": "gnumake",
+      "broken": false,
+      "derivation": "/nix/store/cy06y5fkvbiif016ab9icsj7vqyyiky1-gnumake-4.4.1.drv",
+      "description": "Tool to control the generation of non-source files from sources",
+      "install_id": "gnumake",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+      "name": "gnumake-4.4.1",
+      "pname": "gnumake",
+      "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+      "rev_count": 940249,
+      "rev_date": "2026-02-04T09:32:58Z",
+      "scrape_date": "2026-02-06T06:05:47.941579Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "4.4.1",
+      "outputs_to_install": [
+        "man",
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/fa0f3msdrc5il96nn5qvrbhf6779vvh1-gnumake-4.4.1-debug",
+        "doc": "/nix/store/j2vz6gm38023yfg359cnawzvabqc0w9v-gnumake-4.4.1-doc",
+        "info": "/nix/store/2pqq9mdchp0s0cgl1qqql38v502kbdi1-gnumake-4.4.1-info",
+        "man": "/nix/store/an38a5jy0ivp1504yjbzgl4prvhjnix7-gnumake-4.4.1-man",
+        "out": "/nix/store/5lyy21zm97pj8l67r2xapdkxpxb6v6y0-gnumake-4.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "build",
+      "priority": 5
+    },
+    {
+      "attr_path": "uv",
+      "broken": false,
+      "derivation": "/nix/store/dlp3p1pzksliq0pli84ff5ifbvh13211-uv-0.9.28.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+      "name": "uv-0.9.28",
+      "pname": "uv",
+      "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+      "rev_count": 940249,
+      "rev_date": "2026-02-04T09:32:58Z",
+      "scrape_date": "2026-02-06T05:08:27.505844Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.9.28",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/r6g6avldk8dlj30dmk2p2971akkmw9h3-uv-0.9.28"
+      },
+      "system": "aarch64-linux",
+      "group": "build",
+      "priority": 5
+    },
+    {
+      "attr_path": "uv",
+      "broken": false,
+      "derivation": "/nix/store/b88x7x44g3gj9mfw2ql683lfcxqjil95-uv-0.9.28.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+      "name": "uv-0.9.28",
+      "pname": "uv",
+      "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+      "rev_count": 940249,
+      "rev_date": "2026-02-04T09:32:58Z",
+      "scrape_date": "2026-02-06T06:09:00.313627Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.9.28",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/jddcqyx0099mynb7gxr0dd66hkpqqs2r-uv-0.9.28"
+      },
+      "system": "x86_64-linux",
+      "group": "build",
+      "priority": 5
+    },
+    {
+      "attr_path": "cudaPackages_12_2.cuda_cudart",
+      "broken": false,
+      "derivation": "/nix/store/rdrnmq7ymq949plqp8yj9a1flb9bfnzs-cuda_cudart-12.2.140.drv",
+      "description": "CUDA Runtime (cudart). By downloading and using the packages you accept the terms and conditions of the CUDA EULA",
+      "install_id": "cuda_cudart",
+      "license": "CUDA Toolkit End User License Agreement (EULA)",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "name": "cuda_cudart-12.2.140",
+      "pname": "cuda_cudart",
+      "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "rev_count": 788136,
+      "rev_date": "2025-04-23T06:59:22Z",
+      "scrape_date": "2026-06-13T06:08:09.395244716Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "12.2.140",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/rris8m96aj9sxcnjypl40zgfpr7km39h-cuda_cudart-12.2.140-dev",
+        "lib": "/nix/store/8b4rmfd9vz78ngdww525hwbvxslics8z-cuda_cudart-12.2.140-lib",
+        "out": "/nix/store/5a4w0s4ixzkb1zpdaln0nrjzg5yljw1k-cuda_cudart-12.2.140",
+        "static": "/nix/store/pdkc7fi60zfqshm0mwj0wi25i2pzv3bj-cuda_cudart-12.2.140-static",
+        "stubs": "/nix/store/366gvdi7adfprqan6j6f97z7zbba0crw-cuda_cudart-12.2.140-stubs"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 2
+    },
+    {
+      "attr_path": "cudaPackages_12_2.cuda_cudart",
+      "broken": false,
+      "derivation": "/nix/store/94860kc3qcmpn030hw0plxj06sksc01y-cuda_cudart-12.2.140.drv",
+      "description": "CUDA Runtime (cudart). By downloading and using the packages you accept the terms and conditions of the CUDA EULA",
+      "install_id": "cuda_cudart",
+      "license": "CUDA Toolkit End User License Agreement (EULA)",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "name": "cuda_cudart-12.2.140",
+      "pname": "cuda_cudart",
+      "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "rev_count": 788136,
+      "rev_date": "2025-04-23T06:59:22Z",
+      "scrape_date": "2026-06-13T06:08:09.395245962Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "12.2.140",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/3pna51dqszblaqrr27l2ywa43l5fss0w-cuda_cudart-12.2.140-dev",
+        "lib": "/nix/store/x1i4i2ba0bz64h7djbl3zv0jlfa85xm7-cuda_cudart-12.2.140-lib",
+        "out": "/nix/store/xpyi3q9hxihz8bv0pk8acgxnf62bzkr5-cuda_cudart-12.2.140",
+        "static": "/nix/store/5mxyv5w31zvxhcbvb4v2jrd5fpjx26ic-cuda_cudart-12.2.140-static",
+        "stubs": "/nix/store/g0iq8wpzywb9ic8391vpsy3ac0h8iify-cuda_cudart-12.2.140-stubs"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 2
+    },
+    {
+      "attr_path": "cudaPackages_12_2.cuda_nvcc",
+      "broken": false,
+      "derivation": "/nix/store/4pdap9b70avlsrrqbpflvk64v10xpxm5-cuda_nvcc-12.2.140.drv",
+      "description": "CUDA NVCC. By downloading and using the packages you accept the terms and conditions of the CUDA EULA",
+      "install_id": "cuda_nvcc",
+      "license": "CUDA Toolkit End User License Agreement (EULA)",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "name": "cuda_nvcc-12.2.140",
+      "pname": "cuda_nvcc",
+      "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "rev_count": 788136,
+      "rev_date": "2025-04-23T06:59:22Z",
+      "scrape_date": "2026-06-13T06:08:09.395246935Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "12.2.140",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/kkxbr5jsw0xy876bkjjrdsfiqz6qf469-cuda_nvcc-12.2.140",
+        "static": "/nix/store/57dii4nxgsfvq0h7xv3wmbi3ccdwbbsh-cuda_nvcc-12.2.140-static"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 1
+    },
+    {
+      "attr_path": "cudaPackages_12_2.cuda_nvcc",
+      "broken": false,
+      "derivation": "/nix/store/45qhszi9ggfbwfibqxgybhika5xh4yqj-cuda_nvcc-12.2.140.drv",
+      "description": "CUDA NVCC. By downloading and using the packages you accept the terms and conditions of the CUDA EULA",
+      "install_id": "cuda_nvcc",
+      "license": "CUDA Toolkit End User License Agreement (EULA)",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "name": "cuda_nvcc-12.2.140",
+      "pname": "cuda_nvcc",
+      "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "rev_count": 788136,
+      "rev_date": "2025-04-23T06:59:22Z",
+      "scrape_date": "2026-06-13T06:08:09.395251114Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "12.2.140",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/bsbwzjbjv5w7p8f6lsr8x6p2hnqzch0n-cuda_nvcc-12.2.140",
+        "static": "/nix/store/j97hiaw9dx6gbam57pl2929px4701vcq-cuda_nvcc-12.2.140-static"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 1
+    },
+    {
+      "attr_path": "cudaPackages_12_2.cudatoolkit",
+      "broken": false,
+      "derivation": "/nix/store/ym3gl7y134112qz1i9sfj1kbk5flp33y-cuda-merged-12.2.drv",
+      "description": "Wrapper substituting the deprecated runfile-based CUDA installation",
+      "install_id": "cudatoolkit",
+      "license": "CUDA Toolkit End User License Agreement (EULA)",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "name": "cuda-merged-12.2",
+      "pname": "cuda-merged-12.2",
+      "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "rev_count": 788136,
+      "rev_date": "2025-04-23T06:59:22Z",
+      "scrape_date": "2026-06-13T06:08:09.395251890Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "12.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/f1hg9z3z4bwa8fipicfvn7dyr9k0bh80-cuda-merged-12.2"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 3
+    },
+    {
+      "attr_path": "cudaPackages_12_2.cudatoolkit",
+      "broken": false,
+      "derivation": "/nix/store/vij5l7n1xhfnwr87vw2hn857az49faq4-cuda-merged-12.2.drv",
+      "description": "Wrapper substituting the deprecated runfile-based CUDA installation",
+      "install_id": "cudatoolkit",
+      "license": "CUDA Toolkit End User License Agreement (EULA)",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "name": "cuda-merged-12.2",
+      "pname": "cuda-merged-12.2",
+      "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "rev_count": 788136,
+      "rev_date": "2025-04-23T06:59:22Z",
+      "scrape_date": "2026-06-13T06:08:09.395252429Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "12.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ycjxqhrswx0ys5w8bwgb0glr7sl05wjy-cuda-merged-12.2"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 3
+    },
+    {
+      "attr_path": "gcc12",
+      "broken": false,
+      "derivation": "/nix/store/2hf5m9h5015sr6ddi08mkfirfy07zanx-gcc-wrapper-12.4.0.drv",
+      "description": "GNU Compiler Collection, version 12.4.0 (wrapper script)",
+      "install_id": "gcc",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "name": "gcc-wrapper-12.4.0",
+      "pname": "gcc12",
+      "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "rev_count": 788136,
+      "rev_date": "2025-04-23T06:59:22Z",
+      "scrape_date": "2025-04-25T04:36:30.499239Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "12.4.0",
+      "outputs_to_install": [
+        "man",
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/qq46mglv5izdnwi27m8mhwikqlf7xr1v-gcc-wrapper-12.4.0-info",
+        "man": "/nix/store/z3kaz3irj19a09wr4522ahvrngd95x9i-gcc-wrapper-12.4.0-man",
+        "out": "/nix/store/6ccpnmf5w0b1358mnfas1rd8w0zaw0z5-gcc-wrapper-12.4.0"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 4
+    },
+    {
+      "attr_path": "gcc12",
+      "broken": false,
+      "derivation": "/nix/store/m81jxw7h0kaxxgipy1qdkysrw6368dam-gcc-wrapper-12.4.0.drv",
+      "description": "GNU Compiler Collection, version 12.4.0 (wrapper script)",
+      "install_id": "gcc",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "name": "gcc-wrapper-12.4.0",
+      "pname": "gcc12",
+      "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+      "rev_count": 788136,
+      "rev_date": "2025-04-23T06:59:22Z",
+      "scrape_date": "2025-04-25T05:16:20.822710Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "12.4.0",
+      "outputs_to_install": [
+        "man",
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/a4ljbbdrc4yy1l3gf9haksfc7j0jgphd-gcc-wrapper-12.4.0-info",
+        "man": "/nix/store/pjxdzql7f3f9vvl6vzwwb8i14mwz892h-gcc-wrapper-12.4.0-man",
+        "out": "/nix/store/d1zbw1yz0jk4vm6fm7cgxcfkgfr8lpmd-gcc-wrapper-12.4.0"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 4
+    }
+  ]
+}

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -1,0 +1,116 @@
+schema-version = "1.12.0"
+
+
+## Install Packages --------------------------------------------------
+##  $ flox install gum  <- puts a package in [install] section below
+##  $ flox search gum   <- search for a package
+##  $ flox show gum     <- show all versions of a package
+## -------------------------------------------------------------------
+[install]
+cuda_nvcc.pkg-path = "flox-cuda/cudaPackages_12_2.cuda_nvcc"
+cuda_nvcc.systems = ["aarch64-linux", "x86_64-linux"]
+cuda_nvcc.priority = 1
+
+cuda_cudart.pkg-path = "flox-cuda/cudaPackages_12_2.cuda_cudart"
+cuda_cudart.systems = ["aarch64-linux", "x86_64-linux"]
+cuda_cudart.priority = 2
+cuda_cudart.outputs = ["out", "static"]
+
+cudatoolkit.pkg-path = "flox-cuda/cudaPackages_12_2.cudatoolkit"
+cudatoolkit.systems = ["aarch64-linux", "x86_64-linux"]
+cudatoolkit.priority = 3
+
+gcc.pkg-path = "gcc12"
+gcc.systems = ["aarch64-linux", "x86_64-linux"]
+gcc.priority = 4
+
+uv.pkg-path = "uv"
+uv.version = "0.9.28"
+uv.systems = ["aarch64-linux", "x86_64-linux"]
+uv.pkg-group = "build"
+
+gnumake.pkg-path = "gnumake"
+gnumake.systems = ["aarch64-linux", "x86_64-linux"]
+gnumake.pkg-group = "build"
+
+
+## Environment Variables ---------------------------------------------
+##  ... available for use in the activated environment
+##      as well as [hook], [profile] scripts and [services] below.
+## -------------------------------------------------------------------
+[vars]
+CUDA_VERSION = "12.2"
+CUDA_HOME = "$FLOX_ENV"
+CC = "gcc"
+CXX = "g++"
+LIBRARY_PATH = "$FLOX_ENV/lib:$FLOX_ENV/lib/stubs"
+
+
+## Activation Hook ---------------------------------------------------
+##  ... run by _bash_ shell when you run 'flox activate'.
+## -------------------------------------------------------------------
+[hook]
+# on-activate = '''
+#   # -> Set variables, create files and directories
+#   # -> Perform initialization steps, e.g. create a python venv
+#   # -> Useful environment variables:
+#   #      - FLOX_ENV_PROJECT=/home/user/example
+#   #      - FLOX_ENV=/home/user/example/.flox/run
+#   #      - FLOX_ENV_CACHE=/home/user/example/.flox/cache
+# '''
+
+
+## Profile script ----------------------------------------------------
+## ... sourced by _your shell_ when you run 'flox activate'.
+## -------------------------------------------------------------------
+[profile]
+# common = '''
+#   gum style \
+#   --foreground 212 --border-foreground 212 --border double \
+#   --align center --width 50 --margin "1 2" --padding "2 4" \
+#     $INTRO_MESSAGE
+# '''
+## Shell-specific customizations such as setting aliases go here:
+# bash = ...
+# zsh  = ...
+# fish = ...
+
+
+## Services ---------------------------------------------------------
+##  $ flox services start             <- Starts all services
+##  $ flox services status            <- Status of running services
+##  $ flox activate --start-services  <- Activates & starts all
+## ------------------------------------------------------------------
+[services]
+# myservice.command = "python3 -m http.server"
+
+
+## Include ----------------------------------------------------------
+## ... environments to create a composed environment
+## ------------------------------------------------------------------
+[include]
+# environments = [
+#     { dir = "../common" }
+# ]
+
+
+## Build and publish your own packages ------------------------------
+##  $ flox build
+##  $ flox publish
+## ------------------------------------------------------------------
+[build]
+# [build.myproject]
+# description = "The coolest project ever"
+# version = "0.0.1"
+# command = """
+#   mkdir -p $out/bin
+#   cargo build --release
+#   cp target/release/myproject $out/bin/myproject
+# """
+
+
+## Other Environment Options -----------------------------------------
+[options]
+systems = ["aarch64-linux", "x86_64-linux"]
+# Uncomment to disable CUDA detection.
+# cuda-detection = false

--- a/.github/actions/setup-cuda-python-env/action.yml
+++ b/.github/actions/setup-cuda-python-env/action.yml
@@ -10,33 +10,38 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install nvcc and CUDA runtime libraries for cupy
-      uses: Jimver/cuda-toolkit@v0.2.29
-      id: cuda-toolkit
-      with:
-        cuda: 12.6.3
-        sub-packages: '["nvcc", "nvrtc"]'
-        non-cuda-sub-packages: '["libcurand", "libcublas"]'
-        method: "network"
+    - name: Setup Flox environment
+      uses: ./.github/actions/setup-flox
 
     - name: CUDA diagnostic info
       run: |
         nvidia-smi
-        nvcc --version
+        flox activate -c "nvcc --version"
       shell: bash
 
-    - name: Set up the environment
-      uses: ./.github/actions/setup-python-env
-      with:
-        python-version: ${{ inputs.python-version }}
-
-    - name: Build cuda beamformer
-      run: make compile
+    - name: Install Python dependencies
+      run: flox activate -c "uv sync --frozen"
       shell: bash
       env:
-        CC: gcc
-        CXX: g++
+        UV_PYTHON: ${{ inputs.python-version }}
+
+    - name: Check Python version and pip list
+      run: |
+        flox activate -c "uv run --no-sync which python"
+        flox activate -c "uv run --no-sync python --version"
+        flox activate -c "uv pip list"
+      shell: bash
+      env:
+        UV_PYTHON: ${{ inputs.python-version }}
+
+    - name: Build cuda beamformer
+      run: flox activate -c "make compile"
+      shell: bash
+      env:
+        UV_PYTHON: ${{ inputs.python-version }}
 
     - name: Check CuPy/CUDA installation
-      run: uv run --with cupy-cuda12x python -c 'import cupy; cupy.show_config()'
+      run: flox activate -c 'uv run --with cupy-cuda12x python -c "import cupy; cupy.show_config()"'
       shell: bash
+      env:
+        UV_PYTHON: ${{ inputs.python-version }}

--- a/.github/actions/setup-flox/action.yml
+++ b/.github/actions/setup-flox/action.yml
@@ -1,0 +1,34 @@
+name: "Setup Flox Environment"
+description: >-
+  Install Flox, restore/save the Nix store and .flox/cache (python-uv venv), then
+  activate the environment. Use cache-nix-action@v7 (monolithic) so save runs in
+  the action post step after flox activate; restore@v7 alone does not save.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Flox
+      uses: flox/install-flox-action@v2
+      with:
+        trusted-environments: flox/python-uv
+
+    - name: Restore and save Nix store
+      uses: nix-community/cache-nix-action@v7
+      with:
+        primary-key: nix-store-${{ runner.os }}-${{ hashFiles('.flox/env/manifest.lock') }}
+        restore-prefixes-first-match: |
+          nix-store-${{ runner.os }}-
+
+    - name: Cache Flox uv environment
+      uses: actions/cache@v5
+      with:
+        # Flox cache path comes from:
+        # https://github.com/flox/flox/blob/main/cli/flox-rust-sdk/src/models/environment/path_environment.rs#L371-L378
+        path: .flox/cache
+        key: flox-${{ runner.os }}-${{ hashFiles('uv.lock', '.flox/env/manifest.lock') }}
+        restore-keys: |
+          flox-${{ runner.os }}-
+
+    - name: Install Flox packages (first flox activate)
+      shell: bash
+      run: flox activate -c true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,15 +17,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Install nvcc (CUDA compiler)
-        uses: Jimver/cuda-toolkit@v0.2.25
-        id: cuda-toolkit
-        with:
-          method: "network"
-          sub-packages: '["nvcc"]'
+      - name: Setup Flox environment
+        uses: ./.github/actions/setup-flox
 
-      - name: Set up the environment
-        uses: ./.github/actions/setup-python-env
+      - name: Install Python dependencies
+        run: flox activate -c "uv sync --frozen"
+        shell: bash
 
       - name: Check (lint)
-        run: make check
+        run: flox activate -c "make check"
+        shell: bash

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,11 @@ jobs:
       - name: Install Python dependencies
         run: flox activate -c "uv sync --frozen"
         shell: bash
+        env:
+          UV_PYTHON: "3.11"
 
       - name: Check (lint)
         run: flox activate -c "make check"
         shell: bash
+        env:
+          UV_PYTHON: "3.11"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,11 +23,7 @@ jobs:
       - name: Install Python dependencies
         run: flox activate -c "uv sync --frozen"
         shell: bash
-        env:
-          UV_PYTHON: "3.11"
 
       - name: Check (lint)
         run: flox activate -c "make check"
         shell: bash
-        env:
-          UV_PYTHON: "3.11"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Build docs
-        run: make docs
+        run: flox activate -c "make docs"
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -43,17 +43,15 @@ jobs:
           # Key based on known file hashes from cached_download() calls
           key: mach-data-cache-v1-${{ runner.os }}-c93af0781daeebf771e53a42a629d4f311407410166ef2f1d227e9d2a1b8c641-c349dc1d677c561434fd0e4a74142c4a0a44b7e6ae0a42d446c078a528ef58c1
 
-      - name: Install nvcc (CUDA compiler)
-        uses: Jimver/cuda-toolkit@v0.2.25
-        id: cuda-toolkit
-        with:
-          method: "network"
-          sub-packages: '["nvcc"]'
+      - name: Setup Flox environment
+        uses: ./.github/actions/setup-flox
 
-      - name: Set up the environment
-        uses: ./.github/actions/setup-python-env
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Install Python dependencies
+        run: flox activate -c "uv sync --frozen"
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
 
       - name: Run CPU-only unit tests
-        run: uv run --group test --group array pytest tests -v -s -m "no_cuda"
+        run: flox activate -c 'uv run --group test --group array pytest tests -v -s -m "no_cuda"'
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run CUDA unit tests
-        run: make test
+        run: flox activate -c "make test"
 
 
   benchmark:
@@ -77,15 +77,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run CUDA benchmark
-        run: make benchmark
+        run: flox activate -c "make benchmark"
 
       - name: Plot benchmark (runtime)
-        run:
-          uv run --group compare tests/plot_benchmark.py --output .benchmarks/benchmark.png
+        run: flox activate -c "uv run --group compare tests/plot_benchmark.py --output .benchmarks/benchmark.png"
 
       - name: Plot benchmark (throughput)
-        run:
-          uv run --group compare tests/plot_benchmark.py --points-per-second --output .benchmarks/benchmark_pps.png
+        run: flox activate -c "uv run --group compare tests/plot_benchmark.py --points-per-second --output .benchmarks/benchmark_pps.png"
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,16 +28,12 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v4
 
-    - name: Install CUDA
-      uses: Jimver/cuda-toolkit@v0.2.25
-      id: cuda-toolkit
-      with:
-        method: "network"
-        sub-packages: '["nvcc"]'
+    - name: Setup Flox environment
+      uses: ./.github/actions/setup-flox
 
     - name: CUDA diagnostic info
-      run: |
-        nvcc --version
+      run: flox activate -c "nvcc --version"
+      shell: bash
 
     - uses: pypa/cibuildwheel@v2.23
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Build prerequisites:
 * `gcc >= 8`
 * `nvcc >= 11.0`
 
+Or [install Flox](https://flox.dev/docs/install-flox/install) and run `flox activate`.
+
 ### Docker Development
 
 Compile and test without installing the CUDA *toolkit* using our Docker development environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,8 @@ docs = [
 
 [tool.uv]
 default-groups = "all"
+# CMake/nanobind requires Python dev headers, which uv-managed installs have
+python-preference = "only-managed"
 
 [tool.deptry]
 known_first_party = [


### PR DESCRIPTION
#### Introduction

Adds a [Flox](https://flox.dev) environment for compiling `mach` from source without installing the CUDA toolkit system-wide. Complements the existing Docker workflow with a lighter-weight, native Linux option.

CUDA 12.2 is pinned to match common driver support (e.g. NVIDIA 535.x). Python dependencies remain in the project `.venv` via `uv sync` — Flox supplies the build toolchain only.

#### Changes

- **`.flox/env/manifest.toml`**: Linux-only environment with:
  - `flox-cuda/cudaPackages_12_2` — `cuda_nvcc`, `cuda_cudart` (incl. static libs), `cudatoolkit`
  - `gcc12` — host compiler compatible with CUDA 12.2 nvcc
  - `uv@0.9.28` and `gnumake` — satisfy `make compile` prerequisites
  - `CC`, `CXX`, `CUDA_HOME`, `LIBRARY_PATH` vars for CMake/nvcc

- **`.flox/env/manifest.lock`**: Locked package resolution for `x86_64-linux` and `aarch64-linux`

- **`README.md`**: One-line Flox alternative under build prerequisites

#### Behavior

**New capability**: contributors with Flox installed can compile with:

```bash
flox activate
make compile
```

**Tested locally**: `make check-system-dep` and `make compile` succeed inside `flox activate` on Linux Mint 22.3 (driver 535, GTX 1060).

**Note**: prebuilt wheels target sm_75/89/90; older GPUs (e.g. GTX 1060, sm_61) can compile but cannot run the extension without adjusting `CMAKE_CUDA_ARCHITECTURES`.

#### Review checklist

- [ ] All existing tests and checks pass
- [x] Unit tests covering the new feature or bugfix have been added (N/A — dev environment)
- [x] The documentation has been updated if necessary (✓ README updated)

Made with [Cursor](https://cursor.com)