### PR TITLE
fix: update PICMUS UFF dataset URL to Zenodo

### DIFF
--- a/examples/plane_wave_compound.py
+++ b/examples/plane_wave_compound.py
@@ -67,7 +67,8 @@ MM_PER_METER = 1000
 print("📂 Downloading PICMUS challenge dataset...")
 
 # Download the UFF data file (cached locally after first download)
-url = "http://www.ustb.no/datasets/PICMUS_experiment_resolution_distortion.uff"
+# Source: https://unioslo.github.io/USTB/datasets.html
+url = "https://zenodo.org/records/20261898/files/PICMUS_experiment_resolution_distortion.uff"
 uff_path = cached_download(
     url,
     expected_size=145_518_524,

--- a/marimo/plane_wave_compound.py
+++ b/marimo/plane_wave_compound.py
@@ -78,7 +78,8 @@ def _():
 @app.cell
 def _(cached_download, hashlib):
     # Download PICMUS Challenge Dataset (runs once, cached)
-    url = "http://www.ustb.no/datasets/PICMUS_experiment_resolution_distortion.uff"
+    # Source: https://unioslo.github.io/USTB/datasets.html
+    url = "https://zenodo.org/records/20261898/files/PICMUS_experiment_resolution_distortion.uff"
     uff_path = cached_download(
         url,
         expected_size=145_518_524,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,8 @@ def xp(request):
 @pytest.fixture(scope="session")
 def picmus_phantom_resolution_uff() -> Uff:
     """Download the UFF data of the Picmus phantom resolution UFF file."""
-    url = "http://www.ustb.no/datasets/PICMUS_experiment_resolution_distortion.uff"
+    # Source: https://unioslo.github.io/USTB/datasets.html
+    url = "https://zenodo.org/records/20261898/files/PICMUS_experiment_resolution_distortion.uff"
     uff_path = cached_download(
         url,
         expected_size=145_518_524,


### PR DESCRIPTION
## Summary
- Update PICMUS `PICMUS_experiment_resolution_distortion.uff` download URLs from `ustb.no` (now 404 via GitHub Pages redirect) to the current Zenodo host
- Affects test fixtures, example script, and marimo notebook

## Source
USTB datasets page: https://unioslo.github.io/USTB/datasets.html  
Zenodo file: https://zenodo.org/records/20261898/files/PICMUS_experiment_resolution_distortion.uff

File size and SHA-256 hash are unchanged.

## Test plan
- [x] `flox activate -- make test` — 142 passed, 2 skipped locally
- [x] CI green on PR


Made with [Cursor](https://cursor.com)