### PR TITLE
Upgrade to nanobind 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NOT SKBUILD)
   in your environment once and use the following command that avoids
   a costly creation of a new virtual environment at every compilation:
   =====================================================================
-    pip install nanobind scikit-build-core[pyproject]
+    pip install 'nanobind>=3.0.1,<4' scikit-build-core[pyproject]
     pip install --no-build-isolation -ve .
   =====================================================================
   You may optionally add -Ceditable.rebuild=true to auto-rebuild when

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install-python-dep: ## Installs the Python dependencies
 compile: check-system-dep ## Compiles the CUDA extension with nanobind
 	@echo "Compiling CUDA extension with nanobind..."
 	@echo "If you get an scikit-build-core error, you may need to 'uv cache clean' and 'trash build/'"
-	uv pip install scikit-build-core nanobind ninja cmake
+	uv pip install scikit-build-core 'nanobind>=3.0.1,<4' ninja cmake
 	uv sync --group build
 	# Not sure if the pip command is also needed
 	uv pip install -ve . --no-build-isolation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ preview = true
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",  # make warnings errors
+    "ignore:.*No NVIDIA driver was found.*:RuntimeWarning",
     "ignore:.*This will add latency due to CPU<->GPU memory transfers.*:UserWarning",
     # vbeam warnings
     "ignore:point_position will be overwritten by the scan.:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "nanobind>=2.7"]
+requires = ["scikit-build-core>=0.10", "nanobind>=3.0.1,<4"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -89,7 +89,7 @@ profile = [
 ]
 build = [
     "scikit-build-core>=0.10",
-    "nanobind>=2.7",
+    "nanobind>=3.0.1,<4",
     "cmake >=3.26.4",
     "ninja >=1.11.1",
 ]
@@ -236,7 +236,7 @@ build = [
 # build-requires explicitly.
 # because cibuildwheel uses Docker, we also need to use --system
 before-build = [
-    "uv pip install --system scikit-build-core>=0.10 nanobind>=2.7 ninja"
+    "uv pip install --system 'scikit-build-core>=0.10' 'nanobind>=3.0.1,<4' ninja"
 ]
 # Need --no-isolation to find nvcc
 build-frontend = { name = "build[uv]", args = ["--no-isolation"] }

--- a/src/mach/kernel.cu
+++ b/src/mach/kernel.cu
@@ -352,21 +352,20 @@ static __device__ __forceinline__ float tukey_apod_weight(float r_norm, float al
  * @brief Check CUDA driver compatibility and warn if incompatible
  *
  * This function checks if the installed CUDA driver is compatible with the
- * NVCC version used to compile this module. Issues a warning if incompatible.
+ * NVCC version used to compile this module. Issues a warning if no driver is
+ * found or if the driver is incompatible.
  */
 static void checkCudaDriverCompatibility() {
     int driverVersion = 0;
 
-    // Get driver version - if this fails, let later CUDA operations handle the error
-    if (cudaDriverGetVersion(&driverVersion) != cudaSuccess) {
-        if (PyErr_WarnEx(PyExc_RuntimeWarning, "Could not get CUDA driver version", 1) < 0) {
+    if (cudaDriverGetVersion(&driverVersion) != cudaSuccess || driverVersion == 0) {
+        // cudaDriverGetVersion reports 0 when no driver is installed
+        if (PyErr_WarnEx(
+                PyExc_RuntimeWarning,
+                "[mach] No NVIDIA driver was found. CUDA beamforming is unavailable.",
+                1) < 0) {
             throw nb::python_error();
         }
-        return;
-    }
-
-    // The runtime reports 0 when no driver is installed
-    if (driverVersion == 0) {
         return;
     }
 

--- a/src/mach/kernel.cu
+++ b/src/mach/kernel.cu
@@ -359,7 +359,14 @@ static void checkCudaDriverCompatibility() {
 
     // Get driver version - if this fails, let later CUDA operations handle the error
     if (cudaDriverGetVersion(&driverVersion) != cudaSuccess) {
-        PyErr_WarnEx(PyExc_RuntimeWarning, "Could not get CUDA driver version", 1);
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, "Could not get CUDA driver version", 1) < 0) {
+            throw nb::python_error();
+        }
+        return;
+    }
+
+    // The runtime reports 0 when no driver is installed
+    if (driverVersion == 0) {
         return;
     }
 
@@ -384,7 +391,9 @@ static void checkCudaDriverCompatibility() {
         "→ Please update your NVIDIA driver to version " +
         std::to_string(nvccMajor) + "." + std::to_string(nvccMinor) + " or newer.";
 
-    PyErr_WarnEx(PyExc_RuntimeWarning, warning_msg.c_str(), 1);
+    if (PyErr_WarnEx(PyExc_RuntimeWarning, warning_msg.c_str(), 1) < 0) {
+        throw nb::python_error();
+    }
 }
 
 /**
@@ -418,7 +427,9 @@ static void checkComputeCapability() {
             std::to_string(MIN_CC_MAJOR) + "." + std::to_string(MIN_CC_MINOR) +
             ". Kernels may fail to load.";
 
-        PyErr_WarnEx(PyExc_RuntimeWarning, warning_msg.c_str(), 1);
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, warning_msg.c_str(), 1) < 0) {
+            throw nb::python_error();
+        }
     }
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1806,7 +1806,7 @@ array = [
 ]
 build = [
     { name = "cmake", specifier = ">=3.26.4" },
-    { name = "nanobind", specifier = ">=2.7" },
+    { name = "nanobind", specifier = ">=3.0.1,<4" },
     { name = "ninja", specifier = ">=1.11.1" },
     { name = "scikit-build-core", specifier = ">=0.10" },
 ]
@@ -2202,11 +2202,11 @@ wheels = [
 
 [[package]]
 name = "nanobind"
-version = "2.12.0"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c6/5c/3b69bc3933ad3c3668ba029ad410ba8ecfdc8ee7262ff1009f3304f3c562/nanobind-2.12.0.tar.gz", hash = "sha256:0ae77c1a88f27153fa57045ee00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee", size = 1002704, upload-time = "2026-02-25T09:41:54.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/11/69cf231c4f3ac4fa724a0b1933c3650fb65aff6b9d7a4c2573b9e4e40077/nanobind-3.0.1.tar.gz", hash = "sha256:f7f0a889c8fb80deaacb95e918d88e05148850a32d2b8eda28446291b2bf7c35", size = 1142340, upload-time = "2026-08-27T22:45:21.806Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/bf/1a54e3573736f3ad15fc599c5dde007937234652a1a7efd62573b4ce3a7e/nanobind-2.12.0-py3-none-any.whl", hash = "sha256:a10d3d88e691dcdf22696f9acd893fda3c5a05635763aea238829d274fcad480", size = 249512, upload-time = "2026-02-25T09:41:52.908Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/261b8281d410d99b22ce47559ce56f98c7548dccf8c25ed70a51fbf42d1f/nanobind-3.0.1-py3-none-any.whl", hash = "sha256:4b49491fe8bf483a5e0342125b8fe56237e490ba642c7e296170b8cd256a7764", size = 316363, upload-time = "2026-08-27T22:45:20.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
#### Introduction

Upgrades to nanobind 3 in place of the earlier cap below 3.

#### Changes

- Require `nanobind>=3.0.1,<4` in `build-system.requires`, the build group, the Makefile and the CMakeLists setup comment. `uv.lock` changes only nanobind.
- Quote the cibuildwheel `before-build` specifiers, since the shell read an unquoted `>=` as a redirect.
- `kernel.cu`: on a CPU-only runner, `cudaDriverGetVersion` succeeds and reports 0, so the import check warned that driver 0.0 is too old. The pytest `"error"` filter made `PyErr_WarnEx` return -1, nothing checked it, and nanobind 3 aborted on the pending exception in `enum_create("InterpolationType")`. Now a failed version query or a version of 0 warns that no NVIDIA driver was found, and the import-time `PyErr_WarnEx` calls throw `nb::python_error` on failure.
- `pyproject.toml`: `filterwarnings` ignores the no-driver warning, so the CPU-only tests still run with warnings as errors.

#### Behavior

Importing mach without a driver now warns `[mach] No NVIDIA driver was found. CUDA beamforming is unavailable.` Locally, `uv lock --locked` (uv 0.7.3) and pre-commit pass. `_cuda_impl.pyi` is not regenerated, since that needs a CUDA build.

Fork CI on this branch, with only CI-only steps added on top (push triggers and two import checks): [Test-CPU](https://github.com/Kayvan-Zahiri/mach/actions/runs/34655201037) passed (47 tests, nanobind 3.0.1), and its import step printed the warning. With `-W error::RuntimeWarning`, the import failed with a Python error, not an abort. [Check](https://github.com/Kayvan-Zahiri/mach/actions/runs/34655201053) and [Build wheels](https://github.com/Kayvan-Zahiri/mach/actions/runs/34655201113) passed.

The GPU tests and the docs build have not run against nanobind 3.
